### PR TITLE
Rename ChallengeSpec.Description JSON field

### DIFF
--- a/types.go
+++ b/types.go
@@ -129,7 +129,7 @@ type Provider struct {
 
 type ChallengeSpec struct {
 	ID          string            `json:"id"`
-	Description string            `json:"desc"`
+	Description string            `json:"description"`
 	Type        ChallengeType     `json:"type"`
 	Secure      bool              `json:"secure"`
 	UnStoreable bool              `json:"unstoreable"`


### PR DESCRIPTION
Change `desc` to `description` to match the current API.