### PR TITLE
add scheduled transactions fetching

### DIFF
--- a/testserver/default.go
+++ b/testserver/default.go
@@ -106,6 +106,52 @@ func NewWithDefaults() *Server {
 		},
 	}
 
+	stxs := []bosgo.Transaction{
+		{
+			ID:            s.nextID(),
+			AccessID:      access.ID,
+			UserAccountID: access.Accounts[0].ID,
+			UserAccount: bosgo.AccountRef{
+				ProviderID: DefaultProviderID,
+				IBAN:       access.Accounts[0].IBAN,
+			},
+			Amount: &bosgo.MoneyAmount{
+				Currency: "EUR",
+				Value:    "-943.34",
+			},
+			EntryDate:      time.Now().AddDate(0, 0, 1),
+			SettlementDate: time.Now().AddDate(0, 0, 1),
+			Usage:          "Goods bought in future",
+			Counterparty: bosgo.Counterparty{
+				Name: "PayPal Europe Sarl",
+				Account: bosgo.AccountRef{
+					ProviderID: "DE-BIN-75290000",
+					IBAN:       "DE84200700245353762745",
+				},
+				Merchant: &bosgo.Merchant{
+					Name: "PayPal",
+				},
+			},
+		},
+		{
+			ID:            s.nextID(),
+			AccessID:      access.ID,
+			UserAccountID: access.Accounts[0].ID,
+			UserAccount: bosgo.AccountRef{
+				ProviderID: DefaultProviderID,
+				IBAN:       access.Accounts[0].IBAN,
+			},
+			Amount: &bosgo.MoneyAmount{
+				Currency: "EUR",
+				Value:    "0.34",
+			},
+			EntryDate:      time.Now().AddDate(0, 0, 1),
+			SettlementDate: time.Now().AddDate(0, 0, 1),
+			Usage:          "Interesting payment",
+			Counterparty:   bosgo.Counterparty{},
+		},
+	}
+
 	rtxs := []bosgo.RepeatedTransaction{
 		{
 			ID:            s.nextID(),
@@ -134,9 +180,10 @@ func NewWithDefaults() *Server {
 	}
 
 	ad := AccessDetails{
-		Access:               *access,
-		Transactions:         txs,
-		RepeatedTransactions: rtxs,
+		Access:                *access,
+		Transactions:          txs,
+		RepeatedTransactions:  rtxs,
+		ScheduledTransactions: stxs,
 		ChallengeMap: map[string]string{
 			ChallengeLogin: DefaultAccessLogin,
 			ChallengePIN:   DefaultAccessPIN,

--- a/testserver/server_test.go
+++ b/testserver/server_test.go
@@ -371,6 +371,33 @@ func TestGetAccess(t *testing.T) {
 	}
 }
 
+func TestListScheduledTransactions(t *testing.T) {
+	s := NewWithDefaults()
+	if testing.Verbose() {
+		s.SetLogger(t)
+	}
+	defer s.Close()
+
+	appClient := bosgo.NewAppClient(s.Client(), s.Addr(), DefaultApplicationID)
+	userClient, err := appClient.Users.Login(DefaultUsername, DefaultPassword).Send()
+	if err != nil {
+		t.Fatalf("failed to login as user: %v", err)
+	}
+
+	_, _, err = addDefaultAccess(userClient)
+	if err != nil {
+		t.Fatalf("failed to add access: %v", err)
+	}
+
+	txs, err := userClient.ScheduledTransactions.List().Send()
+	if err != nil {
+		t.Fatalf("failed to retrieve scheduled  transactions: %v", err)
+	}
+	if len(txs) != 2 {
+		t.Errorf("got %d transactions, wanted 2", len(txs))
+	}
+}
+
 func TestListTransactions(t *testing.T) {
 	s := NewWithDefaults()
 	if testing.Verbose() {

--- a/user.go
+++ b/user.go
@@ -883,19 +883,29 @@ func (r *ListScheduledTransactionsReq) ClientID(id string) *ListScheduledTransac
 	return r
 }
 
-func (r *ListScheduledTransactionsReq) Send() (*TransactionPage, error) {
+func (r *ListScheduledTransactionsReq) AccountID(id int64) *ListScheduledTransactionsReq {
+	r.req.par["account_id"] = []string{strconv.FormatInt(id, 10)}
+	return r
+}
+
+func (r *ListScheduledTransactionsReq) AccessID(id int64) *ListScheduledTransactionsReq {
+	r.req.par["access_id"] = []string{strconv.FormatInt(id, 10)}
+	return r
+}
+
+func (r *ListScheduledTransactionsReq) Send() ([]Transaction, error) {
 	res, cleanup, err := r.req.get()
 	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
 
-	var page TransactionPage
-	if err := json.NewDecoder(res.Body).Decode(&page.Transactions); err != nil {
+	var txs []Transaction
+	if err := json.NewDecoder(res.Body).Decode(&txs); err != nil {
 		return nil, decodeError(err, res)
 	}
 
-	return &page, nil
+	return txs, nil
 }
 
 func (a *ScheduledTransactionsService) Get(id string) *GetScheduledTransactionReq {


### PR DESCRIPTION
The scheduled txs endpoint doesn't have the page wrapping, it's a naked slice of txs - filterable by account and access id.