### PR TITLE
Added filtering of scheduled transactions Computed field

### DIFF
--- a/testserver/default.go
+++ b/testserver/default.go
@@ -121,7 +121,7 @@ func NewWithDefaults() *Server {
 			},
 			EntryDate:      time.Now().AddDate(0, 0, 1),
 			SettlementDate: time.Now().AddDate(0, 0, 1),
-			Usage:          "Goods bought in future",
+			Usage:          "Goods bought in future which was computed",
 			Counterparty: bosgo.Counterparty{
 				Name: "PayPal Europe Sarl",
 				Account: bosgo.AccountRef{
@@ -132,6 +132,7 @@ func NewWithDefaults() *Server {
 					Name: "PayPal",
 				},
 			},
+			Computed: true,
 		},
 		{
 			ID:            s.nextID(),
@@ -147,8 +148,9 @@ func NewWithDefaults() *Server {
 			},
 			EntryDate:      time.Now().AddDate(0, 0, 1),
 			SettlementDate: time.Now().AddDate(0, 0, 1),
-			Usage:          "Interesting payment",
+			Usage:          "Interesting payment which was NOT computed",
 			Counterparty:   bosgo.Counterparty{},
+			Computed:       false,
 		},
 	}
 

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -1254,7 +1254,23 @@ func (s *Server) handleScheduledTransactions(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	s.sendJSON(w, http.StatusOK, user.ScheduledTransactions)
+	includeComputed := req.URL.Query().Get("computed")
+	if includeComputed == "" {
+		s.sendJSON(w, http.StatusOK, user.ScheduledTransactions)
+	}
+
+	includeComputedBool, err := strconv.ParseBool(includeComputed)
+	if err != nil {
+		s.sendError(w, http.StatusBadRequest, err.Error())
+	}
+
+	txs := []bosgo.Transaction{}
+	for _, tx := range user.ScheduledTransactions {
+		if includeComputedBool || !tx.Computed {
+			txs = append(txs, tx)
+		}
+	}
+	s.sendJSON(w, http.StatusOK, txs)
 }
 
 func (s *Server) handleRepeatedTransactions(w http.ResponseWriter, req *http.Request) {

--- a/testserver/server_test.go
+++ b/testserver/server_test.go
@@ -399,6 +399,47 @@ func TestListScheduledTransactions(t *testing.T) {
 	}
 }
 
+func TestListScheduledTransactionsComputedFilter(t *testing.T) {
+	s := NewWithDefaults()
+	if testing.Verbose() {
+		s.SetLogger(t)
+	}
+	defer s.Close()
+
+	appClient := bosgo.NewAppClient(s.Client(), s.Addr(), DefaultApplicationID)
+	userClient, err := appClient.Users.Login(DefaultUsername, DefaultPassword).Send()
+	if err != nil {
+		t.Fatalf("failed to login as user: %v", err)
+	}
+
+	_, _, err = addDefaultAccess(userClient)
+	if err != nil {
+		t.Fatalf("failed to add access: %v", err)
+	}
+
+	txs, err := userClient.ScheduledTransactions.List().Computed(true).Send()
+	if err != nil {
+		t.Fatalf("failed to retrieve scheduled  transactions: %v", err)
+	}
+	if len(txs) != 2 {
+		t.Errorf("got %d transactions, wanted 2", len(txs))
+	}
+
+	txs, err = userClient.ScheduledTransactions.List().Computed(false).Send()
+	if err != nil {
+		t.Fatalf("failed to retrieve scheduled  transactions: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Errorf("got %d transactions, wanted 1", len(txs))
+	}
+	if txs[0].Computed {
+		t.Error("got a scheduled transaction with computed true, when asked for only NOT computed txs")
+	}
+	if txs[0].Usage != "Interesting payment which was NOT computed" {
+		t.Errorf("got incorrect tx %s", txs[0].Usage)
+	}
+}
+
 func TestListTransactions(t *testing.T) {
 	s := NewWithDefaults()
 	if testing.Verbose() {

--- a/types.go
+++ b/types.go
@@ -301,6 +301,7 @@ type Transaction struct {
 	Amount                *MoneyAmount `json:"amount,omitempty"`
 	Usage                 string       `json:"usage,omitempty"`
 	TransactionType       string       `json:"transaction_type,omitempty"`
+	Computed              bool         `json:"computed,omitempty"`
 }
 
 type AccountRef struct {

--- a/user.go
+++ b/user.go
@@ -893,6 +893,11 @@ func (r *ListScheduledTransactionsReq) AccessID(id int64) *ListScheduledTransact
 	return r
 }
 
+func (r *ListScheduledTransactionsReq) Computed(includeComputed bool) *ListScheduledTransactionsReq {
+	r.req.par["computed"] = []string{strconv.FormatBool(includeComputed)}
+	return r
+}
+
 func (r *ListScheduledTransactionsReq) Send() ([]Transaction, error) {
 	res, cleanup, err := r.req.get()
 	defer cleanup()


### PR DESCRIPTION
Adding an option to the user client to filter scheduled transaction from
bankrs to include or exclude transactions based on the state of the
Computed field.

Computed transactions are true, if they originate from a Standing order -
the nearest occurrence in the future. The field is false, if the txs is
a regular tx scheduled explicitly for a time in future.