### PR TITLE
testserver: Cleans Transfer.Errors after provide pin success

### DIFF
--- a/testserver/server.go
+++ b/testserver/server.go
@@ -708,6 +708,7 @@ func (s *Server) progressTransfer(tr *TransferOrder, confirm bool, answers []bos
 					tr.Transfer.Step.Data.AuthMethods = append(tr.Transfer.Step.Data.AuthMethods, bosgo.AuthMethod{ID: ta.Method})
 				}
 
+				tr.Transfer.Errors = nil
 				return
 			}
 		}


### PR DESCRIPTION
Currently, bosgo testserver is keeping Transfer.Errors in memory even
after a success.  For example, if users provide their PIN incorrectly
once and then provide the correct one, the initial error is kept in the
object.

This PR ensure that we clean those errors.