### PR TITLE
bosgo client: allow usage of http as a URL scheme.

### DIFF
--- a/app.go
+++ b/app.go
@@ -31,6 +31,7 @@ type AppClient struct {
 	applicationID string
 	ua            string
 	environment   string
+	forceUnsecure bool
 	retryPolicy   RetryPolicy
 
 	Categories *CategoriesService
@@ -67,6 +68,7 @@ func (a *AppClient) newReq(path string) req {
 		par:         params{},
 		environment: a.environment,
 		retryPolicy: a.retryPolicy,
+		forceUnsecure: a.forceUnsecure,
 	}
 }
 
@@ -85,6 +87,7 @@ func (a *AppClient) WithUserToken(token string) *UserClient {
 	uc.ua = a.ua
 	uc.environment = a.environment
 	uc.retryPolicy = a.retryPolicy
+	uc.forceUnsecure = a.forceUnsecure
 	return uc
 }
 

--- a/req.go
+++ b/req.go
@@ -40,6 +40,7 @@ type req struct {
 	requestsAttempted int
 	retryPolicy       RetryPolicy
 	allowRetry        bool
+	forceUnsecure     bool
 }
 
 func (r *req) url() *url.URL {
@@ -48,6 +49,9 @@ func (r *req) url() *url.URL {
 		Host:     r.addr,
 		Path:     r.path,
 		RawQuery: r.par.Encode(),
+	}
+	if r.forceUnsecure {
+		u.Scheme = "http"
 	}
 	return &u
 }

--- a/service.go
+++ b/service.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-
 	// Version is the current version of the bosgo library.
 	Version = "0.1"
 
@@ -42,11 +41,12 @@ const (
 // safe for concurrent use by multiple goroutines.
 type Client struct {
 	// never modified once they have been set
-	hc          *http.Client
-	addr        string
-	ua          string
-	environment string
-	retryPolicy RetryPolicy
+	hc            *http.Client
+	addr          string
+	ua            string
+	environment   string
+	retryPolicy   RetryPolicy
+	forceUnsecure bool
 }
 
 type ClientOption func(*Client)
@@ -75,6 +75,7 @@ func (c *Client) newReq(path string) req {
 		par:         params{},
 		environment: c.environment,
 		retryPolicy: c.retryPolicy,
+		forceUnsecure: c.forceUnsecure,
 	}
 }
 
@@ -93,6 +94,7 @@ func (c *Client) WithApplicationID(applicationID string) *AppClient {
 	ac.ua = c.ua
 	ac.environment = c.environment
 	ac.retryPolicy = c.retryPolicy
+	ac.forceUnsecure = c.forceUnsecure
 	return ac
 }
 
@@ -322,5 +324,12 @@ func Environment(environment string) ClientOption {
 func WithRetryPolicy(policy RetryPolicy) ClientOption {
 	return func(c *Client) {
 		c.retryPolicy = policy
+	}
+}
+
+// WithForcedUnsecuredConnection is a client option thatforces http usage over https
+func WithForcedUnsecuredConnection(fu bool) ClientOption {
+	return func(c *Client) {
+		c.forceUnsecure = fu
 	}
 }

--- a/user.go
+++ b/user.go
@@ -35,6 +35,7 @@ type UserClient struct {
 	applicationID string
 	ua            string
 	environment   string
+	forceUnsecure bool
 	retryPolicy   RetryPolicy
 
 	Accesses              *AccessesService
@@ -87,6 +88,7 @@ func (u *UserClient) newReq(path string) req {
 		par:         params{},
 		environment: u.environment,
 		retryPolicy: u.retryPolicy,
+		forceUnsecure: u.forceUnsecure,
 	}
 }
 


### PR DESCRIPTION
The goal of this PR is to enable the usage of this client with http instead of https.