### PR TITLE
Fix case when we dont want to set http.Client

### DIFF
--- a/app.go
+++ b/app.go
@@ -42,6 +42,9 @@ type AppClient struct {
 // NewAppClient creates a new client that may be used to interact with
 // services that require a specific application context.
 func NewAppClient(client *http.Client, addr string, applicationID string) *AppClient {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	ac := &AppClient{
 		hc:            client,
 		addr:          addr,

--- a/developer.go
+++ b/developer.go
@@ -42,6 +42,9 @@ type DevClient struct {
 
 // NewDevClient creates a new developer client, ready to use.
 func NewDevClient(client *http.Client, addr string, token string) *DevClient {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	dc := &DevClient{
 		hc:    client,
 		addr:  addr,

--- a/service.go
+++ b/service.go
@@ -54,6 +54,9 @@ type ClientOption func(*Client)
 // New creates a new client that will use the supplied HTTP client and connect
 // via the specified API host address.
 func New(client *http.Client, addr string, opts ...ClientOption) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	c := &Client{
 		hc:   client,
 		addr: addr,

--- a/user.go
+++ b/user.go
@@ -49,6 +49,9 @@ type UserClient struct {
 
 // NewUserClient creates a new user client, ready to use.
 func NewUserClient(client *http.Client, addr string, token string, applicationID string) *UserClient {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	uc := &UserClient{
 		hc:            client,
 		addr:          addr,


### PR DESCRIPTION
Most common pattern in API libraries is ability to set custom `http.Client`.
In some cases, we dont want to import `net/http` package and we can pass `nil`.
The responsibility of library is to handle those case eg if client is `nil` use a default http client.
