### PR TITLE
BAN-1270-Add new information for an user access

### DIFF
--- a/testdata/bankrs.apib
+++ b/testdata/bankrs.apib
@@ -105,6 +105,15 @@
 + capabilities                            (AccessCapabilities) - Description of the features supported by the access
 + beneficiaries                           (array[Beneficiary],optional) - List of trusted beneficiaries used by the accounts belonging to the access
 + consent_expiration                      (string,optional) - Date when the user granted consent for usage of the access expires
++ user_info                               (UserInfo) - User information related to this access
+
+## UserInfo (object,fixed-type)
+
++ phone_number                       (string,optional) - User phone number, if available
++ last_updated                       (string,optional) - User last account update date, if available
++ kyc_completed                      (string,optional) - User kyc completed date, if available
++ card_activated                     (string,optional) - User card activation date, if available
++ country                            (string,optional) - User residence country, if available
 
 ## Accesses (object,fixed-type)
 

--- a/types.go
+++ b/types.go
@@ -207,16 +207,16 @@ type Access struct {
 	Beneficiaries     []Beneficiary      `json:"beneficiaries,omitempty"`
 	ConsentExpiration time.Time          `json:"consent_expiration,omitempty"`
 	// Personal information of the user, just for this access
-	UserInfo
+	UserInfo UserInfo `json:"user_info,omitempty"`
 }
 
 // UserInfo represents personal information about the user of this access
 type UserInfo struct {
-	UserPhoneNumber   string     `json:"user_phone_number,omitempty"`
-	UserLastUpdated   *time.Time `json:"user_last_updated,omitempty"`
-	UserKYCUpdated    *time.Time `json:"user_kyc_completed,omitempty"`
-	UserCardActivated *time.Time `json:"user_card_activated,omitempty"`
-	UserCountry       string     `json:"user_country,omitempty"`
+	PhoneNumber   string     `json:"phone_number,omitempty"`
+	LastUpdated   *time.Time `json:"last_updated,omitempty"`
+	KYCUpdated    *time.Time `json:"kyc_completed,omitempty"`
+	CardActivated *time.Time `json:"card_activated,omitempty"`
+	Country       string     `json:"country,omitempty"`
 }
 
 type Account struct {

--- a/types.go
+++ b/types.go
@@ -206,6 +206,17 @@ type Access struct {
 	Capabilities      AccessCapabilities `json:"capabilities"`
 	Beneficiaries     []Beneficiary      `json:"beneficiaries,omitempty"`
 	ConsentExpiration time.Time          `json:"consent_expiration,omitempty"`
+	// Personal information of the user, just for this access
+	UserInfo
+}
+
+// UserInfo represents personal information about the user of this access
+type UserInfo struct {
+	UserPhoneNumber   string     `json:"user_phone_number,omitempty"`
+	UserLastUpdated   *time.Time `json:"user_last_updated,omitempty"`
+	UserKYCUpdated    *time.Time `json:"user_kyc_completed,omitempty"`
+	UserCardActivated *time.Time `json:"user_card_activated,omitempty"`
+	UserCountry       string     `json:"user_country,omitempty"`
 }
 
 type Account struct {


### PR DESCRIPTION
I added new information to an user access. In practice, this will be available just for n26.
The bCon PR is:
https://github.com/bankrs/bCon/pull/3710

