### PR TITLE
BAN-1428-Use user id

### DIFF
--- a/app.go
+++ b/app.go
@@ -80,8 +80,8 @@ func (a *AppClient) userAgent() string {
 
 // WithUserToken creates a UserClient with the supplied user token and
 // application ID, copying options set on the receiver.
-func (a *AppClient) WithUserToken(token string) *UserClient {
-	uc := NewUserClient(a.hc, a.addr, token, a.applicationID)
+func (a *AppClient) WithUIDAndUserToken(uid, token string) *UserClient {
+	uc := NewUserClient(a.hc, a.addr, uid, token, a.applicationID)
 	uc.ua = a.ua
 	uc.environment = a.environment
 	uc.retryPolicy = a.retryPolicy
@@ -281,7 +281,7 @@ func (r *UserCreateReq) Send() (*UserClient, error) {
 		return nil, decodeError(err, res)
 	}
 
-	return r.client.WithUserToken(t.Token), nil
+	return r.client.WithUIDAndUserToken(t.ID, t.Token), nil
 }
 
 // Login returns a request that may be used to login a user with the given username and password.
@@ -333,7 +333,7 @@ func (r *UserLoginReq) Send() (*UserClient, error) {
 		return nil, decodeError(err, res)
 	}
 
-	return r.client.WithUserToken(t.Token), nil
+	return r.client.WithUIDAndUserToken(t.ID, t.Token), nil
 }
 
 // ResetPassword prepares and returns a request to reset a user's password.

--- a/user.go
+++ b/user.go
@@ -37,6 +37,7 @@ type UserClient struct {
 	environment   string
 	retryPolicy   RetryPolicy
 
+	UUID                  string
 	Accesses              *AccessesService
 	Jobs                  *JobsService
 	Accounts              *AccountsService
@@ -49,12 +50,13 @@ type UserClient struct {
 }
 
 // NewUserClient creates a new user client, ready to use.
-func NewUserClient(client *http.Client, addr string, token string, applicationID string) *UserClient {
+func NewUserClient(client *http.Client, addr string, uid string, token string, applicationID string) *UserClient {
 	uc := &UserClient{
 		hc:            client,
 		addr:          addr,
 		token:         token,
 		applicationID: applicationID,
+		UUID:           uid,
 	}
 	uc.Accesses = NewAccessesService(uc)
 	uc.Jobs = NewJobsService(uc)

--- a/user_test.go
+++ b/user_test.go
@@ -29,7 +29,7 @@ func TestUserLogout(t *testing.T) {
 	hc, cleanup := startTestServer(t, routes)
 	defer cleanup()
 
-	userClient := NewUserClient(hc, SandboxAddr, "usertoken", "appid")
+	userClient := NewUserClient(hc, SandboxAddr, "uid", "usertoken", "appid")
 	err := userClient.Logout().Send()
 	if err != nil {
 		t.Fatalf("failed to send logout request: %v", err)


### PR DESCRIPTION
This is actually made by Gilles Monnier, so that numbrs can use the user id and not the user name.